### PR TITLE
fix: Add missing Apache directory listing index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Index of /algocratic/</title>
+    <style>
+        body {
+            background-color: white;
+            font-family: monospace;
+            margin: 20px;
+        }
+        h1 {
+            font-size: 1.2em;
+        }
+        table {
+            font-family: monospace;
+            font-size: 13px;
+        }
+        a {
+            color: #0000EE;
+            text-decoration: none;
+        }
+        a:visited {
+            color: #551A8B;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        th {
+            text-align: left;
+            border-bottom: 1px solid #000;
+            padding-right: 20px;
+        }
+        td {
+            padding-right: 20px;
+            padding-top: 2px;
+        }
+        .icon {
+            width: 20px;
+            display: inline-block;
+        }
+        address {
+            font-style: italic;
+            margin-top: 20px;
+            padding-top: 10px;
+            border-top: 1px solid #000;
+        }
+    </style>
+</head>
+<body>
+<h1>Index of /algocratic/</h1>
+<table>
+    <tr>
+        <th>[ICO]</th>
+        <th>Name</th>
+        <th>Last modified</th>
+        <th>Size</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td valign="top">[DIR]</td>
+        <td><a href="#">Parent Directory</a></td>
+        <td>&nbsp;</td>
+        <td align="right">  - </td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[DIR]</td>
+        <td><a href="clearance/">clearance/</a></td>
+        <td align="right">31-Jul-2025 09:14  </td>
+        <td align="right">  - </td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[DIR]</td>
+        <td><a href="docs/">docs/</a></td>
+        <td align="right">31-Jul-2025 09:14  </td>
+        <td align="right">  - </td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[DIR]</td>
+        <td><a href="forms/">forms/</a></td>
+        <td align="right">31-Jul-2025 09:14  </td>
+        <td align="right">  - </td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[DIR]</td>
+        <td><a href="static/">static/</a></td>
+        <td align="right">31-Jul-2025 09:14  </td>
+        <td align="right">  - </td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[DIR]</td>
+        <td><a href="website/">website/</a></td>
+        <td align="right">31-Jul-2025 09:14  </td>
+        <td align="right">  - </td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[TXT]</td>
+        <td><a href="CLAUDE.md">CLAUDE.md</a></td>
+        <td align="right">31-Jul-2025 14:37  </td>
+        <td align="right">4.5K</td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[HTM]</td>
+        <td><a href="INDEX.HTM">INDEX.HTM</a></td>
+        <td align="right">31-Jul-2025 15:42  </td>
+        <td align="right"> 27K</td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[TXT]</td>
+        <td><a href="LICENSE">LICENSE</a></td>
+        <td align="right">31-Jul-2025 09:14  </td>
+        <td align="right">1.1K</td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[TXT]</td>
+        <td><a href="README.md">README.md</a></td>
+        <td align="right">31-Jul-2025 09:14  </td>
+        <td align="right">3.2K</td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[TXT]</td>
+        <td><a href="forms/algocratic-eula.md">algocratic-eula.md</a></td>
+        <td align="right">31-Jul-2025 09:14  </td>
+        <td align="right">6.1K</td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[HTM]</td>
+        <td><a href="orientation_packet.html">orientation_packet.html</a></td>
+        <td align="right">31-Jul-2025 09:14  </td>
+        <td align="right"> 12K</td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td valign="top">[HTM]</td>
+        <td><a href="portal.html">portal.html</a></td>
+        <td align="right">31-Jul-2025 14:22  </td>
+        <td align="right"> 18K</td>
+        <td>&nbsp;</td>
+    </tr>
+</table>
+<address>Apache/2.4.54 Server at norrisaftcc.github.io Port 443</address>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Fixes the 404 error by adding the missing Apache-style directory listing page.

## Problem
- Site was showing 404 at root URL
- index.html was accidentally omitted during restructure in PR #18

## Solution  
- Recreated the Apache directory listing page
- Serves as 'tutorial puzzle' entry point
- Users click INDEX.HTM to enter the actual site

## Testing
- [x] index.html renders correctly
- [x] Links to INDEX.HTM and other files work
- [x] Apache styling matches expected appearance

Fixes #22